### PR TITLE
chore: Import sort plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
       "jsx": true
     }
   },
-  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import"],
+  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import", "simple-import-sort"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
@@ -73,14 +73,13 @@
         ]
       }
     ],
-    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
-    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
     "import/no-useless-path-segments": [
       "warn",
       {
         "noUselessIndex": true
       }
-    ]
+    ],
+    "simple-import-sort/imports": "warn"
   },
   "settings": {
     "react": {
@@ -101,6 +100,30 @@
       },
       "env": {
         "jest": true
+      }
+    },
+    {
+      "files": ["src/**", "pages/**", "test/**", "scripts/**"],
+      "rules": {
+        "simple-import-sort/imports": [
+          "warn",
+          {
+            "groups": [
+              // External packages come first.
+              ["^react", "^\\w", "^@testing", "^@vite"],
+              // Cloudscape packages.
+              ["^@cloudscape"],
+              // Things that start with a letter (or digit or underscore), or `~` followed by a letter.
+              ["^~?\\w"],
+              // Anything not matched in another group.
+              ["^"],
+              // Styles come last.
+              [
+                "^.+\\.?(css)$","^.+\\.?(css.js)$", "^.+\\.?(scss)$", "^.+\\.?(selectors.js)$"
+              ]
+            ]
+          }
+        ]
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -110,7 +110,7 @@
           {
             "groups": [
               // External packages come first.
-              ["^react", "^\\w", "^(?!@cloudscape)@?\\w"],
+              ["^react", "^(?!@cloudscape)@?\\w"],
               // Cloudscape packages.
               ["^@cloudscape"],
               // Things that start with a letter (or digit or underscore), or `~` followed by a letter.

--- a/.eslintrc
+++ b/.eslintrc
@@ -110,7 +110,7 @@
           {
             "groups": [
               // External packages come first.
-              ["^react", "^\\w", "^@testing", "^@vite"],
+              ["^react", "^\\w", "^(?!@cloudscape)@?\\w"],
               // Cloudscape packages.
               ["^@cloudscape"],
               // Things that start with a letter (or digit or underscore), or `~` followed by a letter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unicorn": "^45.0.2",
         "execa": "^6.1.0",
         "globby": "^13.1.3",
@@ -1641,6 +1642,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2110,6 +2126,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4379,6 +4416,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6385,6 +6433,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "45.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
@@ -6918,6 +6975,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -8795,6 +8872,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -11775,6 +11865,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -13226,6 +13325,25 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/webdriver": {
@@ -14976,6 +15094,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -15281,6 +15414,27 @@
       "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
       "dev": true,
       "optional": true
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -17038,6 +17192,17 @@
         "possible-typed-array-names": "^1.0.0"
       }
     },
+    "axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -18627,6 +18792,13 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-plugin-unicorn": {
       "version": "45.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
@@ -18916,6 +19088,12 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
     "for-each": {
@@ -20236,6 +20414,19 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {
@@ -22445,6 +22636,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -23451,6 +23651,19 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "webdriver": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^45.0.2",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "execa": "^6.1.0",
     "globby": "^13.1.3",
     "husky": "^8.0.3",

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { HashRouter, Link, Route, Routes, useLocation } from "react-router-dom";
+
 import { pages } from "../pages";
 import Page from "./page";
 

--- a/pages/app/page.tsx
+++ b/pages/app/page.tsx
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import SpaceBetween from "@cloudscape-design/components/space-between";
-import Toggle from "@cloudscape-design/components/toggle";
-import { Density, Mode, applyDensity, applyMode } from "@cloudscape-design/global-styles";
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Toggle from "@cloudscape-design/components/toggle";
+import { applyDensity, applyMode, Density, Mode } from "@cloudscape-design/global-styles";
+
 import { pagesMap } from "../pages";
 import PageLayout from "./page-layout";
 

--- a/pages/app/test-bed.tsx
+++ b/pages/app/test-bed.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from "react";
+
 import classnames from "./test-bed.module.css";
 
 export const TestBed = ({ children }: { children: ReactNode }) => (

--- a/pages/avatar/simple.page.tsx
+++ b/pages/avatar/simple.page.tsx
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from "react";
+
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Toggle from "@cloudscape-design/components/toggle";
-import { useState } from "react";
+
 import { Avatar } from "../../lib/components";
 
 export default function AvatarPage() {

--- a/pages/loading-bar/simple.page.tsx
+++ b/pages/loading-bar/simple.page.tsx
@@ -3,6 +3,7 @@
 
 import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
+
 import { LoadingBar } from "../../lib/components";
 import { TestBed } from "../app/test-bed";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
-import "@cloudscape-design/global-styles/index.css";
 
 import App from "./app";
+
+import "@cloudscape-design/global-styles/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -3,6 +3,7 @@
 import path from "node:path";
 
 import { documentComponents, documentTestUtils } from "@cloudscape-design/documenter";
+
 import { dashCase, listPublicDirs, writeSourceFile } from "./utils.js";
 
 const publicDirs = listPublicDirs("src");

--- a/scripts/package-json.js
+++ b/scripts/package-json.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import fs from "node:fs";
+
 import { writeJSON } from "./utils.js";
 
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));

--- a/scripts/test-utils.js
+++ b/scripts/test-utils.js
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import fs from "node:fs";
-import path from "node:path";
-import { default as convertToSelectorUtil } from "@cloudscape-design/test-utils-converter";
 import { execaSync } from "execa";
 import { globbySync } from "globby";
+import fs from "node:fs";
+import path from "node:path";
+
+import { default as convertToSelectorUtil } from "@cloudscape-design/test-utils-converter";
+
 import { pascalCase, writeSourceFile } from "./utils.js";
 
 const components = globbySync(["src/test-utils/dom/**/index.ts", "!src/test-utils/dom/index.ts"]).map((fileName) =>

--- a/scripts/themeable-source.js
+++ b/scripts/themeable-source.js
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { globbySync } from "globby";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { globbySync } from "globby";
 const cwd = process.cwd();
 
 const targetDir = path.join(cwd, "./lib/components-themeable/internal");

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import lodash from "lodash";
 import fs from "node:fs";
 import path from "node:path";
-import lodash from "lodash";
 
 export function pascalCase(text) {
   return capitalize(lodash.camelCase(text));

--- a/src/__tests__/base-props-support.test.tsx
+++ b/src/__tests__/base-props-support.test.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactElement } from "react";
-import { describe, expect, test } from "vitest";
 import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
 
 import { defaultProps } from "./default-props";
 import { getAllComponents, requireComponent } from "./utils";

--- a/src/__tests__/base-props-support.test.tsx
+++ b/src/__tests__/base-props-support.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render } from "@testing-library/react";
 import { ReactElement } from "react";
 import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
 import { defaultProps } from "./default-props";
 import { getAllComponents, requireComponent } from "./utils";
 

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 import { getAllComponents, requireComponentDefinition } from "./utils";
 
 test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 // type-only import, because in runtime it tries to access Jest globals, which do not exist
 /// <reference types="@testing-library/jest-dom" />
-import { expect } from "vitest";
 import matchers from "@testing-library/jest-dom/matchers";
+import { expect } from "vitest";
 
 expect.extend(matchers);

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 // type-only import, because in runtime it tries to access Jest globals, which do not exist
 /// <reference types="@testing-library/jest-dom" />
-import matchers from "@testing-library/jest-dom/matchers";
 import { expect } from "vitest";
+import matchers from "@testing-library/jest-dom/matchers";
 
 expect.extend(matchers);

--- a/src/avatar/__tests__/avatar.test.tsx
+++ b/src/avatar/__tests__/avatar.test.tsx
@@ -1,11 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as ComponentToolkitInternal from "@cloudscape-design/component-toolkit/internal";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+import * as ComponentToolkitInternal from "@cloudscape-design/component-toolkit/internal";
+
 import Avatar, { AvatarProps } from "../../../lib/components/avatar";
-import loadingDotsStyles from "../../../lib/components/avatar/loading-dots/styles.selectors.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
+
+import loadingDotsStyles from "../../../lib/components/avatar/loading-dots/styles.selectors.js";
 
 const defaultAvatarProps: AvatarProps = { ariaLabel: "Avatar" };
 

--- a/src/avatar/__tests__/avatar.test.tsx
+++ b/src/avatar/__tests__/avatar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, describe, expect, test, vi } from "vitest";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import * as ComponentToolkitInternal from "@cloudscape-design/component-toolkit/internal";
 

--- a/src/avatar/internal.tsx
+++ b/src/avatar/internal.tsx
@@ -1,17 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useRef, useState } from "react";
+import clsx from "clsx";
+
 import { warnOnce } from "@cloudscape-design/component-toolkit/internal";
 import Icon from "@cloudscape-design/components/icon";
 import Tooltip from "@cloudscape-design/components/internal/tooltip-do-not-use";
-import clsx from "clsx";
-import { useRef, useState } from "react";
 
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
 import { useMergeRefs } from "../internal/utils/use-merge-refs";
-
 import { AvatarProps } from "./interfaces.js";
 import LoadingDots from "./loading-dots";
+
 import styles from "./styles.css.js";
 
 export interface InternalAvatarProps extends AvatarProps, InternalBaseComponentProps {}

--- a/src/avatar/loading-dots/index.tsx
+++ b/src/avatar/loading-dots/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
+
 import styles from "./styles.css.js";
 
 interface LoadingDotsProps {

--- a/src/internal/base-component/__tests__/use-base-component.test.tsx
+++ b/src/internal/base-component/__tests__/use-base-component.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { expect, test, vi } from "vitest";
 import { render } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
 
 import { COMPONENT_METADATA_KEY } from "@cloudscape-design/component-toolkit/internal";
 

--- a/src/internal/base-component/__tests__/use-base-component.test.tsx
+++ b/src/internal/base-component/__tests__/use-base-component.test.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { COMPONENT_METADATA_KEY } from "@cloudscape-design/component-toolkit/internal";
-import { render } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+import { COMPONENT_METADATA_KEY } from "@cloudscape-design/component-toolkit/internal";
+
 import useBaseComponent, {
   InternalBaseComponentProps,
 } from "../../../../lib/components/internal/base-component/use-base-component";

--- a/src/internal/base-component/use-base-component.ts
+++ b/src/internal/base-component/use-base-component.ts
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { MutableRefObject } from "react";
+
 import {
   ComponentConfiguration,
   initAwsUiVersions,
   useComponentMetadata,
 } from "@cloudscape-design/component-toolkit/internal";
-import { MutableRefObject } from "react";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from "../environment";
 import useFocusVisible from "../utils/focus-visible";
 import { useTelemetry } from "./use-telemetry";

--- a/src/internal/base-component/use-telemetry.ts
+++ b/src/internal/base-component/use-telemetry.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ComponentConfiguration, useComponentMetrics } from "@cloudscape-design/component-toolkit/internal";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from "../environment";
 import { useVisualRefresh } from "./use-visual-refresh";
 

--- a/src/internal/base-component/use-visual-refresh.ts
+++ b/src/internal/base-component/use-visual-refresh.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRuntimeVisualRefresh } from "@cloudscape-design/component-toolkit/internal";
+
 import { ALWAYS_VISUAL_REFRESH } from "../environment";
 
 export const useVisualRefresh = ALWAYS_VISUAL_REFRESH ? () => true : useRuntimeVisualRefresh;

--- a/src/internal/utils/__tests__/focus-visible.test.tsx
+++ b/src/internal/utils/__tests__/focus-visible.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, describe, expect, test, vi } from "vitest";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import useFocusVisible from "../../../../lib/components/internal/utils/focus-visible";
 

--- a/src/internal/utils/__tests__/focus-visible.test.tsx
+++ b/src/internal/utils/__tests__/focus-visible.test.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
 import useFocusVisible from "../../../../lib/components/internal/utils/focus-visible";
 
 function Fixture() {

--- a/src/internal/utils/__tests__/use-merge-refs.test.tsx
+++ b/src/internal/utils/__tests__/use-merge-refs.test.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // eslint-disable-next-line no-restricted-imports
 import React from "react";
-import { describe, expect, test, vi } from "vitest";
 import { render } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
 
 import { useMergeRefs } from "../use-merge-refs";
 

--- a/src/internal/utils/__tests__/use-merge-refs.test.tsx
+++ b/src/internal/utils/__tests__/use-merge-refs.test.tsx
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render } from "@testing-library/react";
 // eslint-disable-next-line no-restricted-imports
 import React from "react";
 import { describe, expect, test, vi } from "vitest";
+import { render } from "@testing-library/react";
+
 import { useMergeRefs } from "../use-merge-refs";
 
 const Demo = React.forwardRef((props, ref) => {

--- a/src/internal/utils/focus-visible.ts
+++ b/src/internal/utils/focus-visible.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { useEffect } from "react";
+
 import { KeyCode } from "../keycode";
 
 export function isModifierKey(event: KeyboardEvent) {

--- a/src/loading-bar/__tests__/loading-bar.test.tsx
+++ b/src/loading-bar/__tests__/loading-bar.test.tsx
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
 import LoadingBar from "../../../lib/components/loading-bar";
-import styles from "../../../lib/components/loading-bar/styles.css.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
+
+import styles from "../../../lib/components/loading-bar/styles.css.js";
 
 describe("LoadingBar", () => {
   afterEach(() => {

--- a/src/loading-bar/__tests__/loading-bar.test.tsx
+++ b/src/loading-bar/__tests__/loading-bar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
 
 import LoadingBar from "../../../lib/components/loading-bar";
 import createWrapper from "../../../lib/components/test-utils/dom";

--- a/src/loading-bar/internal.tsx
+++ b/src/loading-bar/internal.tsx
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
+
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
-
 import { LoadingBarProps } from "./interfaces";
+
 import styles from "./styles.css.js";
 
 export function InternalLoadingBar({

--- a/src/test-utils/dom/avatar/index.ts
+++ b/src/test-utils/dom/avatar/index.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import TooltipWrapper from "@cloudscape-design/components/test-utils/dom/internal/tooltip";
 import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+
 import createWrapper from "..";
+
 import avatarStyles from "../../../avatar/styles.selectors.js";
 
 export default class AvatarWrapper extends ComponentWrapper {

--- a/src/test-utils/dom/loading-bar/index.ts
+++ b/src/test-utils/dom/loading-bar/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+
 import loadingBarStyles from "../../../loading-bar/styles.selectors.js";
 
 export default class LoadingBarWrapper extends ComponentWrapper {

--- a/test/functional/utils/focus-visible.test.ts
+++ b/test/functional/utils/focus-visible.test.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from "vitest";
+
 import { BasePageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import createWrapper from "@cloudscape-design/components/test-utils/selectors";
-import { describe, expect, test } from "vitest";
+
 import { setupTest } from "../../utils";
 
 const wrapper = createWrapper();

--- a/test/visual-test-setup.ts
+++ b/test/visual-test-setup.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { join } from "path";
 import { configureToMatchImageSnapshot } from "jest-image-snapshot";
+import { join } from "path";
 import { expect } from "vitest";
 
 const snapshotDir = join(__dirname, "./..", process.env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY ?? "__image_snapshots__");

--- a/test/visual/index.test.ts
+++ b/test/visual/index.test.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import path from "path";
-import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import { expect, test } from "vitest";
+
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import { setupTest } from "../utils";
 
 const pagesMap = import.meta.glob("../../pages/**/*.page.tsx", { as: "raw" });


### PR DESCRIPTION
### Description

Introduced a new plugin to group and alphabetically sort imports in the following order:

external packages
cloudscape packages
internal imports
styles

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
