### PR TITLE
fix: JAWS issue in avatar

### DIFF
--- a/pages/avatar/permutations.page.tsx
+++ b/pages/avatar/permutations.page.tsx
@@ -32,7 +32,7 @@ export default function AvatarPage() {
       <main>
         <TestBed>
           <Avatar ariaLabel="User avatar" />
-          <Avatar color="gen-ai" iconName="gen-ai" ariaLabel="User avatar" />
+          <Avatar color="gen-ai" iconName="gen-ai" ariaLabel="Gen AI assistant" />
 
           <Avatar initials="GW" ariaLabel="User avatar GW" tooltipText="User avatar" />
           <Avatar color="gen-ai" initials="GW" ariaLabel="Gen AI assistant GW" tooltipText="Gen AI assistant" />
@@ -45,8 +45,8 @@ export default function AvatarPage() {
             tooltipText="Gen AI assistant generating response"
           />
 
-          <Avatar iconSvg={customIconSvg} ariaLabel="Avatar loading" />
-          <Avatar color="gen-ai" iconSvg={customIconSvg} ariaLabel="Gen AI assistant loading" />
+          <Avatar iconSvg={customIconSvg} ariaLabel="Avatar with custom SVG icon" />
+          <Avatar color="gen-ai" iconSvg={customIconSvg} ariaLabel="Gen AI avatar with custom SVG icon" />
         </TestBed>
       </main>
     </ScreenshotArea>

--- a/src/avatar/internal.tsx
+++ b/src/avatar/internal.tsx
@@ -94,7 +94,9 @@ export default function InternalAvatar({
         />
       )}
 
-      <div className={styles.content}>
+      {/* aria-hidden is added so that screen readers focus only the parent div */}
+      {/* when it is not hidden, it becomes unstable in JAWS */}
+      <div className={styles.content} aria-hidden="true">
         <AvatarContent
           color={color}
           ariaLabel={ariaLabel}


### PR DESCRIPTION
### Description

JAWS was skipping some avatars and it wasn't reading the aria-labels. Adding aria-hidden to content div fixed this issue. The content of avatar is now not focusable which was the intended implementation for avatar. Additionally fixed the aria-labels in the permutation page.

Related links, issue #, if available: n/a

### How has this been tested?

Used the permutations page to test.
- For VoiceOver, tested in Chrome, Firefox and Safari
- For JAWS and NVDA, tested in Chrome and Firefox

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
