### PR TITLE
fix: Chat bubble test name

### DIFF
--- a/src/chat-bubble/__tests__/chat-bubble.test.tsx
+++ b/src/chat-bubble/__tests__/chat-bubble.test.tsx
@@ -74,7 +74,7 @@ describe("Chat bubble", () => {
     expect(wrapper.findLoadingBar()!.getElement()).toBeVisible();
   });
 
-  test("findLoadingBar returns null when set to false", () => {
+  test("findLoadingBar returns null when showLoadingBar is set to false", () => {
     const wrapper = renderChatBubble({
       type: "outgoing",
       avatar: <Avatar ariaLabel="Avatar" />,


### PR DESCRIPTION
### Description
Fix chat bubble test name and get design token update to propagate in chat components

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
