### PR TITLE
fix: Add offset to avatar's focus-visible outline

### DIFF
--- a/src/avatar/styles.scss
+++ b/src/avatar/styles.scss
@@ -35,7 +35,7 @@ $avatar-size: 28px;
     outline: none;
 
     @include shared.when-visible {
-      @include shared.focus-highlight(1px, 50%);
+      @include shared.focus-highlight(4px, 50%);
     }
   }
 


### PR DESCRIPTION
### Description

The offset fixes any color contrast ambiguities the focus color could have against the avatar background color. No reason for the focus ring to hug the control like that when other components don't do it that way.

Related links, issue #, if available: AWSUI-60284

### How has this been tested?

Visual tests should handle it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
