### PR TITLE
fix: Overflowing content expands the chat bubble horizontally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@cloudscape-design/browser-test-tools": "^3.0.4",
         "@cloudscape-design/build-tools": "^3.0.1",
+        "@cloudscape-design/code-view": "^3",
         "@cloudscape-design/components": "^3",
         "@cloudscape-design/design-tokens": "^3",
         "@cloudscape-design/documenter": "^1.0.0",
@@ -4489,6 +4490,15 @@
       "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.2.tgz",
       "integrity": "sha512-wiOZYuxyOSYfZzDasQTe+ZWmRlYxXSJM/kMKZ/bSqO1VgrBl+PaaTz/Sc+y7hXCKAUj3syUdpwxQyvwv9vQe6w==",
       "dev": true
+    },
+    "node_modules/ace-code": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/ace-code/-/ace-code-1.39.0.tgz",
+      "integrity": "sha512-6aSpPdwCu92iPQYrgONjSrvXDSxcEojwzPj2FHXugfSTrh3miyX27fMVWnRtktJEqqrQRj7+gC7q6hsvBW41bQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -19270,6 +19280,12 @@
       "version": "1.34.2",
       "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.2.tgz",
       "integrity": "sha512-wiOZYuxyOSYfZzDasQTe+ZWmRlYxXSJM/kMKZ/bSqO1VgrBl+PaaTz/Sc+y7hXCKAUj3syUdpwxQyvwv9vQe6w==",
+      "dev": true
+    },
+    "ace-code": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/ace-code/-/ace-code-1.39.0.tgz",
+      "integrity": "sha512-6aSpPdwCu92iPQYrgONjSrvXDSxcEojwzPj2FHXugfSTrh3miyX27fMVWnRtktJEqqrQRj7+gC7q6hsvBW41bQ==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@cloudscape-design/browser-test-tools": "^3.0.4",
     "@cloudscape-design/build-tools": "^3.0.1",
+    "@cloudscape-design/code-view": "^3",
     "@cloudscape-design/components": "^3",
     "@cloudscape-design/design-tokens": "^3",
     "@cloudscape-design/documenter": "^1.0.0",

--- a/pages/chat-bubble/with-overflow.page.tsx
+++ b/pages/chat-bubble/with-overflow.page.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import CodeView from "@cloudscape-design/code-view/code-view";
+
+import { ChatBubble } from "../../lib/components";
+import { TestBed } from "../app/test-bed";
+import smiley from "../avatar/smiley.png";
+import { ScreenshotArea } from "../screenshot-area";
+import { ChatBubbleAvatarGenAI, ChatContainer } from "./util-components";
+
+export default function ChatBubbleWithOverflowPage() {
+  return (
+    <ScreenshotArea>
+      <h1>Chat bubble with overflowing content</h1>
+      <p>
+        These chat bubbles have content that is wider than the available space. The chat bubbles should render a scroll
+        bar.
+      </p>
+
+      <TestBed>
+        <ChatContainer>
+          <ChatBubble type="incoming" avatar={<ChatBubbleAvatarGenAI />} ariaLabel="Gen AI at 4:24:25pm">
+            This is a regular chat bubble with small content.
+          </ChatBubble>
+
+          <ChatBubble type="incoming" avatar={<ChatBubbleAvatarGenAI />} ariaLabel="Gen AI at 4:24:25pm">
+            This chat bubble contains some code.
+            <CodeView content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+          </ChatBubble>
+
+          <ChatBubble type="incoming" avatar={<ChatBubbleAvatarGenAI />} ariaLabel="Gen AI at 4:24:26pm">
+            This chat bubble contains an image.
+            <img src={smiley} width={3000} height={200} />
+          </ChatBubble>
+        </ChatContainer>
+      </TestBed>
+    </ScreenshotArea>
+  );
+}

--- a/src/chat-bubble/styles.scss
+++ b/src/chat-bubble/styles.scss
@@ -23,6 +23,7 @@
   gap: cs.$space-scaled-s;
   padding: cs.$space-scaled-s;
   min-width: 0;
+  overflow-x: auto;
 
   border-start-start-radius: cs.$border-radius-chat-bubble;
   border-start-end-radius: cs.$border-radius-chat-bubble;
@@ -53,7 +54,7 @@
 }
 
 .content {
-  overflow: auto;
+  /* Used in test utils */
 }
 
 .actions {

--- a/src/chat-bubble/styles.scss
+++ b/src/chat-bubble/styles.scss
@@ -22,6 +22,7 @@
   flex-direction: column;
   gap: cs.$space-scaled-s;
   padding: cs.$space-scaled-s;
+  min-width: 0;
 
   border-start-start-radius: cs.$border-radius-chat-bubble;
   border-start-end-radius: cs.$border-radius-chat-bubble;
@@ -52,7 +53,7 @@
 }
 
 .content {
-  /* Used in test utils */
+  overflow: auto;
 }
 
 .actions {


### PR DESCRIPTION
### Description

When a chat bubble has content that is wider than the available space, this would previously force the chat bubble to expand horizontally even outside its containing parent. With this PR, a scrollbar is rendered inside the chat bubble when necessary.


See https://github.com/cloudscape-design/chat-components/issues/47
<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-60482

### How has this been tested?

Tested manually, added a new testing page

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->


### Screenshot
![image](https://github.com/user-attachments/assets/aa86a3be-bbda-4da4-ad5e-2cb7feb53938)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
