### PR TITLE
chore: Skip documenter snapshots

### DIFF
--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 
 import { getAllComponents, requireComponentDefinition } from "./utils";
 
-test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
+test.skip.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
   const definition = requireComponentDefinition(componentName);
 
   // overriding with a fake value so that when there are icon changes in components this test doesn't block it


### PR DESCRIPTION
### Description

Preparing this change to land: https://github.com/cloudscape-design/documenter/pull/58

After that change is landed I will enable and re-generate snapshots

Related links, issue #, if available: n/a

### How has this been tested?

Test change only

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
