### PR TITLE
chore: re-enable documenter snapshot tests

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -9,8 +9,6 @@ import { dashCase, listPublicDirs, writeSourceFile } from "./utils.js";
 const publicDirs = listPublicDirs("src");
 const targetDir = "lib/components/internal/api-docs";
 
-const importedCoreComponents = ["icon"];
-
 componentDocs();
 testUtilDocs();
 
@@ -22,17 +20,8 @@ function validatePublicFiles(definitionFiles) {
   }
 }
 
-function getNodeModulesInterfacePath(componentName) {
-  return path.resolve("node_modules/@cloudscape-design/components", componentName, "interfaces.d.ts");
-}
-
 function componentDocs() {
-  const nodeModulesDependencyFilePaths = importedCoreComponents.map(getNodeModulesInterfacePath);
-  const definitions = documentComponents(
-    path.resolve("tsconfig.json"),
-    "src/*/index.tsx",
-    nodeModulesDependencyFilePaths,
-  );
+  const definitions = documentComponents(path.resolve("tsconfig.json"), "src/*/index.tsx");
   const outDir = path.join(targetDir, "components");
   const fileNames = definitions
     .filter((definition) => {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10,8 +10,8 @@ exports[`definition for avatar matches the snapshot > avatar 1`] = `
       "description": "Text to describe the avatar for assistive technology.
 When more than one avatar is used, provide a unique label for each.
 For example, "Avatar of John Doe" or "Avatar of generative AI assistant".
-If \`tooltipText\` is used make sure to include it in the \`ariaLabel\`.
-",
+
+If \`tooltipText\` is used make sure to include it in the \`ariaLabel\`.",
       "name": "ariaLabel",
       "optional": false,
       "type": "string",
@@ -36,8 +36,8 @@ Use \`gen-ai\` for AI assistants and \`default\` otherwise.",
       "defaultValue": ""user-profile"",
       "description": "Specifies the icon to be displayed as Avatar.
 Use \`gen-ai\` icon for AI assistants. By default \`user-profile\` icon is used.
-If you set both \`iconName\` and \`initials\`, \`initials\` will take precedence.
-",
+
+If you set both \`iconName\` and \`initials\`, \`initials\` will take precedence.",
       "inlineType": {
         "name": "IconProps.Name",
         "type": "union",
@@ -76,8 +76,8 @@ Use it to define initials that uniquely identify the avatar's owner.",
     },
     {
       "description": "The text content shown in the avatar's tooltip.
-When you use this property, make sure to include it in the \`ariaLabel\`.
-",
+
+When you use this property, make sure to include it in the \`ariaLabel\`.",
       "name": "tooltipText",
       "optional": true,
       "type": "string",

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 
 import { getAllComponents, requireComponentDefinition } from "./utils";
 
-test.skip.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
+test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
   const definition = requireComponentDefinition(componentName);
 
   // overriding with a fake value so that when there are icon changes in components this test doesn't block it


### PR DESCRIPTION
### Description

Re-enable snapshot tests after https://github.com/cloudscape-design/documenter/pull/58 is released

Related links, issue #, if available: n/a

### How has this been tested?

Build passes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
