### PR TITLE
chore: Migrate to the new documenter API

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -2,41 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import path from "node:path";
 
-import { documentComponents, documentTestUtils } from "@cloudscape-design/documenter";
+import { documentTestUtils, writeComponentsDocumentation } from "@cloudscape-design/documenter";
 
-import { listPublicDirs, writeSourceFile } from "./utils.js";
+import { writeSourceFile } from "./utils.js";
 
-const publicDirs = listPublicDirs("src");
 const targetDir = "lib/components/internal/api-docs";
 
 componentDocs();
 testUtilDocs();
 
-function validatePublicFiles(definitionFiles) {
-  for (const publicDir of publicDirs) {
-    if (!definitionFiles.includes(publicDir)) {
-      throw new Error(`Directory src/${publicDir} does not have a corresponding API definition`);
-    }
-  }
-}
-
 function componentDocs() {
-  const definitions = documentComponents({
+  writeComponentsDocumentation({
+    outDir: path.join(targetDir, "components"),
     tsconfigPath: path.resolve("tsconfig.json"),
     publicFilesGlob: "src/*/index.tsx",
   });
-  const outDir = path.join(targetDir, "components");
-  for (const definition of definitions) {
-    writeSourceFile(
-      path.join(outDir, definition.dashCaseName + ".js"),
-      `module.exports = ${JSON.stringify(definition, null, 2)};`,
-    );
-  }
-  const indexContent = `module.exports = {
-    ${definitions.map((definition) => `${JSON.stringify(definition.dashCaseName)}:require('./${definition.dashCaseName}')`).join(",\n")}
-  }`;
-  writeSourceFile(path.join(outDir, "index.js"), indexContent);
-  validatePublicFiles(definitions.map((def) => def.dashCaseName));
 }
 
 function testUtilDocs() {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -42,7 +42,9 @@ If you set both \`iconName\` and \`initials\`, \`initials\` will take precedence
       "inlineType": {
         "name": "IconProps.Name",
         "type": "union",
-        "values": "comes from @cloudscape-design/components",
+        "values": [
+          "comes from @cloudscape-design/components",
+        ],
       },
       "name": "iconName",
       "optional": true,

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
 
-import { getAllComponents, requireComponentDefinition } from "./utils";
+import componentDefinitions from "../../lib/components/internal/api-docs/components";
+import { getAllComponents } from "./utils";
 
 test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
-  const definition = requireComponentDefinition(componentName);
+  const definition = componentDefinitions[componentName];
 
   // overriding with a fake value so that when there are icon changes in components this test doesn't block it
-  const iconNameDefinition = definition.properties.filter(({ name }: { name: string }) => name === "iconName");
-  if (iconNameDefinition && iconNameDefinition[0]) {
-    iconNameDefinition[0].inlineType.values = "comes from @cloudscape-design/components";
+  const iconNameDefinition = definition.properties.find(({ name }: { name: string }) => name === "iconName");
+  if (iconNameDefinition && iconNameDefinition.inlineType?.type === "union") {
+    iconNameDefinition.inlineType.values = ["comes from @cloudscape-design/components"];
   }
   expect(definition).toMatchSnapshot(componentName);
 });

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -6,7 +6,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const componentsDir = path.resolve(__dirname, "../../lib/components");
-const definitionsDir = path.resolve(__dirname, "../../lib/components/internal/api-docs/components");
 
 export function getAllComponents(): string[] {
   return fs
@@ -19,11 +18,6 @@ export function getAllComponents(): string[] {
         !name.includes("LICENSE") &&
         !name.includes("NOTICE"),
     );
-}
-
-export function requireComponentDefinition(componentName: string) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require(path.join(definitionsDir, componentName));
 }
 
 export async function requireComponent(componentName: string) {


### PR DESCRIPTION
### Description

Same as https://github.com/cloudscape-design/components/pull/3475 but for this package

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Inspected files locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
