### PR TITLE
chore: remove dependency on the tooltip wrapper

### DIFF
--- a/src/avatar/internal.tsx
+++ b/src/avatar/internal.tsx
@@ -106,6 +106,7 @@ export default function InternalAvatar({
     >
       {showTooltip && tooltipText && (
         <Tooltip
+          className={styles.tooltip}
           value={tooltipText}
           trackRef={handleRef}
           // This is added to ensure tooltip is closed when clicked for consistency with other tooltip usages

--- a/src/avatar/styles.scss
+++ b/src/avatar/styles.scss
@@ -76,3 +76,7 @@
     );
   }
 }
+
+.tooltip {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/avatar/index.ts
+++ b/src/test-utils/dom/avatar/index.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import TooltipWrapper from "@cloudscape-design/components/test-utils/dom/internal/tooltip";
-import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+import { ComponentWrapper, ElementWrapper } from "@cloudscape-design/test-utils-core/dom";
 
 import createWrapper from "..";
 
@@ -10,7 +9,7 @@ import avatarStyles from "../../../avatar/styles.selectors.js";
 export default class AvatarWrapper extends ComponentWrapper {
   static rootSelector: string = avatarStyles.root;
 
-  findTooltip(): TooltipWrapper | null {
-    return createWrapper().findComponent(`.${TooltipWrapper.rootSelector}`, TooltipWrapper);
+  findTooltip(): ElementWrapper | null {
+    return createWrapper().find(`.${avatarStyles.tooltip}`);
   }
 }


### PR DESCRIPTION
### Description

Unblock this change: https://github.com/cloudscape-design/chat-components/pull/89

TooltipWrapper is an empty class we can replace it with `ElementWrapper` to simplify dependencies

https://github.com/cloudscape-design/components/blob/3b136937f369cec711df914e867d99992ff8372c/src/test-utils/dom/internal/tooltip.ts#L7-L9

### How has this been tested?

Test-util change only, PR build is enough

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
