### PR TITLE
chore(support-prompt-group): use borderRadiusSupportPrompt token for corner radius

### DIFF
--- a/src/support-prompt-group/styles.scss
+++ b/src/support-prompt-group/styles.scss
@@ -37,10 +37,10 @@
 
   border-block: 1px solid awsui.$color-border-button-normal-default;
   border-inline: 1px solid awsui.$color-border-button-normal-default;
-  border-start-start-radius: awsui.$space-static-xs;
-  border-start-end-radius: awsui.$space-static-xs;
-  border-end-start-radius: awsui.$space-static-xs;
-  border-end-end-radius: awsui.$space-static-xs;
+  border-start-start-radius: awsui.$border-radius-support-prompt;
+  border-start-end-radius: awsui.$border-radius-support-prompt;
+  border-end-start-radius: awsui.$border-radius-support-prompt;
+  border-end-end-radius: awsui.$border-radius-support-prompt;
 
   inline-size: fit-content;
 


### PR DESCRIPTION
The support prompt group's corner radius uses the dedicated `borderRadiusSupportPrompt` design token (`awsui.$border-radius-support-prompt`) for all four corners.

**Dependency:** requires `borderRadiusSupportPrompt` to be published in `@cloudscape-design/design-tokens` (cloudscape-design/components#4923). Kept as a **draft** until that token lands and publishes — the build will be red until the token is available in the consumed design-tokens version.
