### PR TITLE
feat: upload fork pull request coverage to Codecov

### DIFF
--- a/.github/workflows/codecov-fork-upload.yml
+++ b/.github/workflows/codecov-fork-upload.yml
@@ -1,0 +1,16 @@
+name: Codecov fork upload
+
+on:
+  workflow_run:
+    workflows: ["Build, lint and test"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  codecov-fork:
+    uses: cloudscape-design/actions/.github/workflows/codecov-fork-upload.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Change

Adds a thin `workflow_run` wrapper that calls the privileged reusable workflow in `cloudscape-design/actions`, restoring Codecov coverage for fork pull requests. Fork PRs run without secrets, so `CODECOV_TOKEN` is unavailable and the upload cannot happen from the build job.

This mirrors the existing `deploy-fork-preview.yml` wrapper in this repository — same filename convention, trigger shape, workflow-level `permissions`, job naming and `secrets: inherit` — so the fork-preview and fork-coverage flows now cover the same repositories. No `with:` is passed because the reusable workflow's `artifact-name` input defaults to `coverage-report`.

All privileged logic lives in `cloudscape-design/actions`; this file is only the rollout unit. It never checks out or executes fork code.

## Verified for this repo, not assumed

The caller workflow's `name:` is exactly `Build, lint and test`, matching this wrapper's `workflow_run.workflows` entry. `workflow_run` matches on workflow *name*, so a mismatch would silently never fire.

`coverage/` is confirmed as the correct output path: `vite.config.unit.mjs` enables vitest coverage when `CI === "true"` and sets no `reportsDirectory`, so vitest writes to its default `./coverage`. Configured reporters are clover, lcov, html and json.

## Rollout order

`cloudscape-design/actions#131` has already landed (`d3eca61` on `main`), so `codecov-fork-upload.yml@main` resolves and this wrapper has no pending prerequisite. It does not depend on `cloudscape-design/actions#132` either: that PR only adds an optional `coverage-artifact-name` input for matrix callers, and the default this wrapper relies on is unchanged.

The upstream workflow uploads to Codecov for real, and runs with `continue-on-error: true`, so a failure there can never block a pull request. The attribution risk and the first-run checks are documented in #131; they are not duplicated here.

## Must never be a required status check

This workflow deliberately does not run on `merge_group` (it only triggers on `workflow_run` of a pull request build). Adding it as a required status check would deadlock the merge queue.

Context: cloudscape-design/actions#131, cloudscape-design/build-tools#78.

